### PR TITLE
fix: Navbar Themes button is made being in use based on the screen size

### DIFF
--- a/src/components/Themes/ThemesNew.jsx
+++ b/src/components/Themes/ThemesNew.jsx
@@ -92,7 +92,7 @@ function BigTheme(props) {
 		<>
 			<section
 				className="max-md:hidden flex flex-col justify-center items-center text-white w-[75%] mt-11 backdrop-blur-sm p-4 font-kode rounded-lg"
-				id="themes"
+				id="theme"
 			>
 				{/* carousel */}
 				<h3 className="text-[aliceblue] text-[2.5rem] text-center font-kode font-extrabold m-8">Themes</h3>

--- a/src/components/navbar/Navbar.jsx
+++ b/src/components/navbar/Navbar.jsx
@@ -20,8 +20,14 @@ function Normalnav() {
                     About
                 </button>
                 <button
+                    onClick={() => scrollToSection('#theme')}
+                    className="max-md:hidden block w-max no-underline px-2.5 text-lg rounded-[30px] transition-all hover:rounded-[72px] hover:bg-[#bb13fe81] hover:shadow-[0_0_0.2rem_#fff,0_0_0.2rem_#fff,0_0_0.5rem_#bc13fe,0_0_0.5rem_#bc13fe,inset_0_0_0.5rem_#bc13fe]"
+                >
+                    Themes
+                </button>
+                <button
                     onClick={() => scrollToSection('#themes')}
-                    className="block w-max no-underline px-2.5 text-lg rounded-[30px] transition-all hover:rounded-[72px] hover:bg-[#bb13fe81] hover:shadow-[0_0_0.2rem_#fff,0_0_0.2rem_#fff,0_0_0.5rem_#bc13fe,0_0_0.5rem_#bc13fe,inset_0_0_0.5rem_#bc13fe]"
+                    className="block w-max no-underline px-2.5 text-lg rounded-[30px] transition-all hover:rounded-[72px] hover:bg-[#bb13fe81] hover:shadow-[0_0_0.2rem_#fff,0_0_0.2rem_#fff,0_0_0.5rem_#bc13fe,0_0_0.5rem_#bc13fe,inset_0_0_0.5rem_#bc13fe] mdHidden"
                 >
                     Themes
                 </button>

--- a/src/index.css
+++ b/src/index.css
@@ -67,3 +67,8 @@ body{
 }
 
 
+@media (max-width: 767px), (min-width: 1025px) {
+  .mdHidden {
+    display: none;
+  }
+}


### PR DESCRIPTION
This pull request improves the navigation experience for the "Themes" section by updating the scroll targets and adjusting visibility of navigation buttons based on screen size. The changes ensure that users on different devices see the correct navigation options and that the scroll behavior matches the updated section identifiers.

Navigation and scroll behavior updates:

* The `id` of the main themes section in `ThemesNew.jsx` was changed from `themes` to `theme`, aligning it with the updated scroll target.
* In `Navbar.jsx`, a new navigation button was added for desktop screens that scrolls to the updated `#theme` section, while the existing button for the old `#themes` target was modified to be hidden on medium and larger screens using the new `mdHidden` class.

Responsive design improvements:

* A new media query was added in `index.css` to hide elements with the `mdHidden` class on screens smaller than 768px and larger than 1024px, ensuring the correct navigation buttons are visible for each device type.